### PR TITLE
PODS-9123:

### DIFF
--- a/app/connectors/LegacySchemeDetailsConnector.scala
+++ b/app/connectors/LegacySchemeDetailsConnector.scala
@@ -43,21 +43,17 @@ class LegacySchemeDetailsConnectorImpl @Inject()(
   private val logger = Logger(classOf[LegacySchemeDetailsConnectorImpl])
 
   def getLegacySchemeDetails(psaId: String, pstr: String)
-                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, JsValue]] = {
+                            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[HttpResponse, JsValue]] = {
     val (url, schemeHc) = (config.legacySchemeDetailsUrl, hc.withExtraHeaders("psaId" -> psaId, "pstr" -> pstr))
 
     http.GET[HttpResponse](url)(implicitly, schemeHc, implicitly).map { response =>
       response.status match {
         case OK =>
-            Right(response.json)
+          Right(response.json)
         case _ =>
           logger.error(response.body)
           Left(response)
       }
     }
   }
-
 }
-
-sealed trait LegacySchemeDetailsConnectorException extends Exception
-

--- a/app/controllers/actions/PsaSchemeAuthAction.scala
+++ b/app/controllers/actions/PsaSchemeAuthAction.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import config.AppConfig
+import connectors.{LegacySchemeDetailsConnector, ListOfSchemesConnector}
+import models.requests.AuthenticatedRequest
+import models.{Items, ListOfLegacySchemes}
+import play.api.Logging
+import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.Results.NotFound
+import play.api.mvc.{ActionFunction, Result}
+import renderer.Renderer
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendHeaderCarrierProvider
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+private class PsaSchemeAuthActionImpl (pstr:String, listOfSchemesConnector: ListOfSchemesConnector, legacySchemeDetailsConnector: LegacySchemeDetailsConnector,
+                                   renderer: Renderer, config: AppConfig)
+                                  (implicit val executionContext: ExecutionContext)
+  extends ActionFunction[AuthenticatedRequest, AuthenticatedRequest] with FrontendHeaderCarrierProvider with Logging {
+
+  private def notFoundTemplate(implicit request: AuthenticatedRequest[_]): Future[Result] =
+    renderer.render("notFound.njk", Json.obj("yourPensionSchemesUrl" -> config.yourPensionSchemesUrl)).map(NotFound(_))
+
+  // TODO: address scalastyle complaint
+  //scalastyle:off
+  override def invokeBlock[A](request: AuthenticatedRequest[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] = {
+
+    val psaIdStr = request.psaId.id
+
+    val listOfSchemes: Future[Either[HttpResponse, ListOfLegacySchemes]] = listOfSchemesConnector
+      .getListOfSchemes(psaIdStr)(hc(request), executionContext)
+
+    val legacySchemeDetails = legacySchemeDetailsConnector
+      .getLegacySchemeDetails(psaIdStr, pstr)(hc(request), executionContext)
+
+    val futureMaybeListOfSchemesForPsa: Future[Option[List[Items]]] = listOfSchemes.flatMap {
+      case Right(list) => Future.successful(list.items)
+      case _ =>
+        logger.info("getListOfSchemes returned None for this PsaID")
+        Future.successful(None)
+    }
+
+    val futureSchemeDetailsForPsaWithPstr = legacySchemeDetails.flatMap {
+      case Right(data) => Future.successful(data.as[JsObject])
+      case _ =>
+        logger.info("getLegacySchemeDetails returned no data for this PsaId and PSTR")
+        Future.successful(Json.obj())
+    }
+
+    val schemeNameFromListOfSchemes: Future[String] = futureMaybeListOfSchemesForPsa.map {
+      case Some(schemes) =>
+        schemes.find(_.pstr == pstr).map { scheme =>
+          scheme.schemeName
+        }.getOrElse("")
+      case _ => ""
+    }
+
+    val schemeNameFromSchemeDetails = futureSchemeDetailsForPsaWithPstr.map { schemeDetails =>
+      (schemeDetails \ "schemeName").asOpt[String].getOrElse("")
+    }
+
+    val futures = for {
+      res1 <- schemeNameFromListOfSchemes
+      res2 <- schemeNameFromSchemeDetails
+    } yield {
+      println("\n\n\n" + res1 + " 0000 "+ res2)
+      if (res1.isEmpty | res2.isEmpty) {
+        notFoundTemplate(request)
+      } else if (res1 == res2) {
+        block(request)
+      } else {
+        notFoundTemplate(request)
+      }
+    } recoverWith {
+      case err =>
+        logger.error("Error: ", err)
+        notFoundTemplate(request)
+    }
+    futures.flatten
+  }
+}
+
+class PsaSchemeAuthAction @Inject()
+(listOfSchemesConnector: ListOfSchemesConnector, legacySchemeDetailsConnector: LegacySchemeDetailsConnector, renderer: Renderer, config: AppConfig)
+(implicit ec: ExecutionContext) {
+  def apply(pstr: String): ActionFunction[AuthenticatedRequest, AuthenticatedRequest] =
+    new PsaSchemeAuthActionImpl(pstr, listOfSchemesConnector, legacySchemeDetailsConnector, renderer, config)
+}

--- a/app/controllers/preMigration/ListOfSchemesController.scala
+++ b/app/controllers/preMigration/ListOfSchemesController.scala
@@ -19,7 +19,7 @@ package controllers.preMigration
 import com.google.inject.Inject
 import config.AppConfig
 import connectors.ListOfSchemesConnector
-import controllers.actions.AuthAction
+import controllers.actions.{AuthAction, PsaSchemeAuthAction}
 import forms.ListSchemesFormProvider
 import models.MigrationType.isRacDac
 import models.requests.AuthenticatedRequest
@@ -42,7 +42,8 @@ class ListOfSchemesController @Inject()(
                                          formProvider: ListSchemesFormProvider,
                                          listOfSchemesConnector: ListOfSchemesConnector,
                                          schemeSearchService: SchemeSearchService,
-                                         lockingService: LockingService
+                                         lockingService: LockingService,
+                                         psaSchemeAuthAction: PsaSchemeAuthAction
                                        )(implicit val ec: ExecutionContext)
   extends FrontendBaseController
     with I18nSupport with NunjucksSupport {
@@ -103,7 +104,7 @@ class ListOfSchemesController @Inject()(
       )
   }
 
-  def clickSchemeLink(pstr: String, isRacDac: Boolean): Action[AnyContent] = authenticate.async {
+  def clickSchemeLink(pstr: String, isRacDac: Boolean): Action[AnyContent] = (authenticate andThen psaSchemeAuthAction(pstr)).async {
     implicit request =>
       lockingService.initialLockSetupAndRedirect(pstr, request, isRacDac)
   }

--- a/test/controllers/actions/PsaSchemeAuthActionSpec.scala
+++ b/test/controllers/actions/PsaSchemeAuthActionSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import config.AppConfig
+import connectors.LegacySchemeDetailsConnector
+import models.requests.AuthenticatedRequest
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import play.api.http.Status.NOT_FOUND
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Results.{NotFound, Ok}
+import play.api.test.Helpers._
+import renderer.Renderer
+import uk.gov.hmrc.domain.PsaId
+import uk.gov.hmrc.http.HttpResponse
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class PsaSchemeAuthActionSpec
+  extends SpecBase with BeforeAndAfterAll with ScalaFutures with MockitoSugar {
+
+  import PsaSchemeAuthActionSpec._
+
+  private val legacySchemeDetailsConnector = mock[LegacySchemeDetailsConnector]
+  private val action = new PsaSchemeAuthAction(legacySchemeDetailsConnector, app.injector.instanceOf[Renderer], app.injector.instanceOf[AppConfig])
+
+  override def afterAll(): Unit = reset(legacySchemeDetailsConnector)
+
+  "PsaSchemeAuthActionSpec" must {
+
+    "return 200 OK if getLegacySchemeDetails succeeds for given PsaId and PSTR" in {
+
+      when(legacySchemeDetailsConnector.getLegacySchemeDetails(any(), any())(any(), any()))
+        .thenReturn(Future.successful(Right(legacySchemeDetailsResponse)))
+
+      val request = AuthenticatedRequest(fakeRequest, externalId, psaId)
+      val result = action(pstr).invokeBlock(request, { _: AuthenticatedRequest[_] => Future.successful(Ok("")) })
+      status(result) mustBe OK
+    }
+
+    "return 404 Not Found if getLegacySchemeDetails fails to retrieve data for a given PsaId and PSTR" in {
+      when(legacySchemeDetailsConnector.getLegacySchemeDetails(any(), any())(any(), any()))
+        .thenReturn(Future.successful(Left(notFoundResponse)))
+
+      val request = AuthenticatedRequest(fakeRequest, externalId, psaId)
+      val result = action(pstr).invokeBlock(request, { _: AuthenticatedRequest[_] => Future.successful(NotFound("")) })
+      status(result) mustBe NOT_FOUND
+      }
+    }
+}
+
+object PsaSchemeAuthActionSpec {
+
+  private val legacySchemeDetailsResponse: JsValue = Json.obj("schemeDetails" -> Json.obj("abc" -> "123"))
+  private val (externalId, psaId, pstr) = ("externalId", PsaId("A0000000"), "pstr")
+  private val notFoundResponse: HttpResponse = HttpResponse(NOT_FOUND, "Not found")
+}

--- a/test/controllers/preMigration/ListOfSchemesControllerSpec.scala
+++ b/test/controllers/preMigration/ListOfSchemesControllerSpec.scala
@@ -21,22 +21,24 @@ import controllers.ControllerSpecBase
 import controllers.actions._
 import forms.ListSchemesFormProvider
 import matchers.JsonMatchers
+import models.requests.AuthenticatedRequest
 import models.{Items, ListOfLegacySchemes, RacDac, Scheme}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalatest.TryValues
-import play.api.mvc.Result
+import play.api.mvc.{ActionFunction, Result}
 import play.api.mvc.Results._
 import play.api.test.Helpers.{status, _}
 import services.{LockingService, SchemeSearchService}
 import uk.gov.hmrc.nunjucks.NunjucksSupport
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 class ListOfSchemesControllerSpec extends ControllerSpecBase with NunjucksSupport with JsonMatchers with TryValues  {
 
   private val mockSchemeSearchService: SchemeSearchService = mock[SchemeSearchService]
   private val mockLockingService: LockingService = mock[LockingService]
   private val mockListOfSchemesConnector: ListOfSchemesConnector = mock[ListOfSchemesConnector]
+  private val mockPsaSchemeAuthAction: PsaSchemeAuthAction = mock[PsaSchemeAuthAction]
   private val schemeDetail = Items("10000678RE", "2020-10-10", racDac = false, "abcdefghi", "2020-12-12", None)
   private val racDacDetail = Items("10000678RF", "2020-10-10", racDac = true, "abcdefghi", "2020-12-12", Some("12345678"))
   private val expectedResponse = ListOfLegacySchemes(1, Some(List(schemeDetail, racDacDetail)))
@@ -46,10 +48,14 @@ class ListOfSchemesControllerSpec extends ControllerSpecBase with NunjucksSuppor
 
   private def controller: ListOfSchemesController =
     new ListOfSchemesController(mockAppConfig, messagesApi, new FakeAuthAction(),
-      controllerComponents, formProvider, mockListOfSchemesConnector, mockSchemeSearchService, mockLockingService)
+      controllerComponents, formProvider, mockListOfSchemesConnector, mockSchemeSearchService, mockLockingService, mockPsaSchemeAuthAction)
 
 
   override def beforeEach(): Unit = {
+    when(mockPsaSchemeAuthAction.apply(any())).thenReturn(new ActionFunction[AuthenticatedRequest, AuthenticatedRequest] {
+      override def invokeBlock[A](request: AuthenticatedRequest[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] = block(request)
+      override protected def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
+    })
     super.beforeEach()
   }
 


### PR DESCRIPTION
Code:
- Added auth action which cross references data from the list of legacy schemes and legacy scheme details APIs. It checks whether a given PSA or PSA/PSTR combination has access to data for a scheme and uses the schemeName field, common to both responses, for matching purposes. If the schemeName doesn't match or other failures occur you will reach Page not found.
- Removed unused custom exception